### PR TITLE
Add cross-compilation + static/shared library target

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,16 +1,26 @@
 PLATFORM := $(shell uname)
 
 MAIN = switchres_main
+TARGET_LIB = libswitchres
 SRC = monitor.cpp modeline.cpp switchres.cpp display.cpp
+OBJS = $(SRC:.cpp=.o)
 
+CROSS_COMPILE ?=
 CXX ?= g++
+AR ?= ar
+LDFLAGS =
+FINAL_CXX=$(CROSS_COMPILE)$(CXX)
+FINAL_AR=$(CROSS_COMPILE)$(AR)
+CPPFLAGS = -O3 -Wall -Wextra
 
 # Linux
 ifeq  ($(PLATFORM),Linux)
 SRC += display_linux.cpp
-CPPFLAGS = -O3
+CPPFLAGS += -fPIC
 LIBS =
 REMOVE = rm -f 
+STATIC_LIB_EXT = a
+DYNAMIC_LIB_EXT = so
 
 # Windows
 else ifneq (,$(findstring NT,$(PLATFORM)))
@@ -18,14 +28,20 @@ SRC += display_windows.cpp custom_video.cpp custom_video_ati_family.cpp custom_v
 CFLAGS = -O3 -static -static-libgcc -static-libstdc++ 
 LIBS = 
 REMOVE = del /f
+STATIC_LIB_EXT = lib
+DYNAMIC_LIB_EXT = dll
 endif
 
 %.o : %.cpp
-		$(CXX) -c $(CPPFLAGS) $< -o $@
+	$(FINAL_CXX) -c $(CPPFLAGS) $< -o $@
 
 all: $(SRC:.cpp=.o) $(MAIN).cpp
-		@echo $(OSFLAG)
-		$(CXX) $(CPPFLAGS) $(SRC:.cpp=.o) $(MAIN).cpp $(LIBS) -o $(MAIN)
+	@echo $(OSFLAG)
+	$(FINAL_CXX) $(CPPFLAGS) $(CXXFLAGS) $(SRC:.cpp=.o) $(MAIN).cpp $(LIBS) -o $(MAIN)
+
+$(TARGET_LIB): $(OBJS)
+	$(FINAL_CXX) $(LDFLAGS) $(CPPFLAGS) -shared -o $@.$(DYNAMIC_LIB_EXT) $^
+	$(FINAL_AR) rcs $@.$(STATIC_LIB_EXT) $(^)
 
 clean:
-		$(REMOVE) $(SRC:.cpp=.o) $(MAIN)
+	$(REMOVE) $(OBJS) $(MAIN) $(TARGET_LIB).*


### PR DESCRIPTION
Hi,

This PR is a 2 in 1:

- allow cross compilation (probably mostly to build from Linux for Windows). Linux users would just `make PLATFORM=NT CROSS_COMPILE=x86_64-w64-mingw32-` for 64bits, or `make PLATFORM=NT CROSS_COMPILE=i686-w64-mingw32-` for 32bits
- you can also build a .dll/.lib for Win32, or .so/.a for Linux with the new `libswitchres` target

Needless to say you can cross compile a dll :wink: 