### PR TITLE
Github actions: add CI

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,0 +1,99 @@
+name: Switchres CI
+
+on: [push]
+
+jobs:
+  linux-build-standalone:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: make
+      run: make
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: switchres linux binary
+        path: switchres_main
+
+  linux-build-lib:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: make
+      run: make libswitchres
+    - name: Prepare artifacts
+      run: mkdir artifacts && cp libswitchres.{so,a} artifacts/
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: switchres linux lib
+        path: artifacts/
+
+  win32-build-x86_64-standalone:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: install_mingw
+      run: sudo apt-get install mingw-w64
+    - name: make
+      run: make PLATFORM=NT CROSS_COMPILE=x86_64-w64-mingw32-
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: switchres win32 x86_64 binary
+        path: switchres_main
+
+  win32-build-x86_64-lib:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: install_mingw
+      run: sudo apt-get install mingw-w64
+    - name: make
+      run: make PLATFORM=NT CROSS_COMPILE=x86_64-w64-mingw32- libswitchres
+    - name: Prepare artifacts
+      run: mkdir artifacts && cp libswitchres.{dll,lib} artifacts/
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: switchres win32 x86_64 lib
+        path: artifacts/
+
+  win32-build-i686-standalone:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: install_mingw
+      run: sudo apt-get install mingw-w64
+    - name: make
+      run: make PLATFORM=NT CROSS_COMPILE=i686-w64-mingw32-
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: switchres win32 i686 binary
+        path: switchres_main
+
+  win32-build-i686-lib:
+
+    runs-on: ubuntu-latest
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: install_mingw
+      run: sudo apt-get install mingw-w64
+    - name: make
+      run: make PLATFORM=NT CROSS_COMPILE=i686-w64-mingw32- libswitchres
+    - name: Prepare artifacts
+      run: mkdir artifacts && cp libswitchres.{dll,lib} artifacts/
+    - name: Upload artifact
+      uses: actions/upload-artifact@v1.0.0
+      with:
+        name: switchres win32 i686 lib
+        path: artifacts/
+


### PR DESCRIPTION
Sets up a small CI that triggers on each pull(commit) in the Actions tab.

Builds lib and switchres_main for linux, win32 32 and 64bits.

Compilation results are downloadable as artifacts if all jobs succeeded.