### PR TITLE
CI: add libxrandr dependencies

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -1,12 +1,14 @@
 name: Switchres CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   linux-build-standalone:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: install dependencies
+      run: sudo apt-get install libxrandr-dev
     - name: make
       run: make
     - name: Upload artifact
@@ -19,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
+    - name: install dependencies
+      run: sudo apt-get install libxrandr-dev
     - name: make
       run: make libswitchres
     - name: Prepare artifacts


### PR DESCRIPTION
Since b6c067cc9ce24ccd7f90e48cdd3de2e859e9a936 CI requires some more prerequisites