### PR TITLE
CI: fix mingw threads by using posix model

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -41,6 +41,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: install_mingw
       run: sudo apt-get install mingw-w64
+    - name: posix_model_x86_64
+      run: sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
     - name: make
       run: make PLATFORM=NT CROSS_COMPILE=x86_64-w64-mingw32-
     - name: Upload artifact
@@ -57,6 +59,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: install_mingw
       run: sudo apt-get install mingw-w64
+    - name: posix_model_x86_64
+      run: sudo update-alternatives --set x86_64-w64-mingw32-g++ /usr/bin/x86_64-w64-mingw32-g++-posix
     - name: make
       run: make PLATFORM=NT CROSS_COMPILE=x86_64-w64-mingw32- libswitchres
     - name: Prepare artifacts
@@ -75,6 +79,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: install_mingw
       run: sudo apt-get install mingw-w64
+    - name: posix_model_i686
+      run: sudo update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
     - name: make
       run: make PLATFORM=NT CROSS_COMPILE=i686-w64-mingw32-
     - name: Upload artifact
@@ -91,6 +97,8 @@ jobs:
     - uses: actions/checkout@v1
     - name: install_mingw
       run: sudo apt-get install mingw-w64
+    - name: posix_model_i686
+      run: sudo update-alternatives --set i686-w64-mingw32-g++ /usr/bin/i686-w64-mingw32-g++-posix
     - name: make
       run: make PLATFORM=NT CROSS_COMPILE=i686-w64-mingw32- libswitchres
     - name: Prepare artifacts


### PR DESCRIPTION
Ubuntu's mingw32 version seems to be lacking proper support for threads. Switching to the posix model solves the issue. Couldn't test the binary though.