### PR TITLE
wrapper: force locale

### DIFF
--- a/switchres_wrapper.cpp
+++ b/switchres_wrapper.cpp
@@ -17,6 +17,7 @@
 #include "switchres_wrapper.h"
 #include "log.h"
 #include <stdio.h>
+#include <locale>
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -25,8 +26,9 @@ switchres_manager* swr;
 
 
 MODULE_API void sr_init() {
+	setlocale(LC_NUMERIC, "C");
 	swr = new switchres_manager;
-	swr->set_log_verbose_fn((void *)printf);
+	//swr->set_log_verbose_fn((void *)printf);
 	swr->set_log_info_fn((void *)printf);
 	swr->set_log_error_fn((void *)printf);
 	swr->parse_config("switchres.ini");


### PR DESCRIPTION
This fixes a bug with Mednafen confusing the decimal separator