### PR TITLE
Add a configurable level of verbosity

### DIFF
--- a/log.cpp
+++ b/log.cpp
@@ -14,6 +14,9 @@
 
 #include "log.h"
 
+enum log_verbosity { NONE, ERROR, INFO, DEBUG };
+static log_verbosity log_level = ERROR;
+
 void log_dummy(const char *, ...) {}
 
 LOG_VERBOSE log_verbose = &log_dummy;
@@ -22,15 +25,28 @@ LOG_ERROR log_error = &log_dummy;
 
 void set_log_verbose(void *func_ptr)
 {
-	log_verbose = (LOG_VERBOSE)func_ptr;
+	if (log_level >= DEBUG)
+		log_verbose = (LOG_VERBOSE)func_ptr;
 }
 
 void set_log_info(void *func_ptr)
 {
-	log_info = (LOG_INFO)func_ptr;
+	if (log_level >= INFO)
+		log_info = (LOG_INFO)func_ptr;
 }
 
 void set_log_error(void *func_ptr)
 {
-	log_error = (LOG_ERROR)func_ptr;
+	if (log_level >= ERROR)
+		log_error = (LOG_ERROR)func_ptr;
+}
+
+void set_log_verbosity(int level)
+{
+	// Keep the log in the enum bounds
+	if (level < NONE)
+		level = NONE;
+	if(level > DEBUG)
+		level = DEBUG;
+	log_level = (log_verbosity)level;
 }

--- a/log.h
+++ b/log.h
@@ -30,6 +30,7 @@ extern LOG_INFO log_info;
 typedef void (*LOG_ERROR)(const char *format, ...) ATTR_PRINTF(1,2);
 extern LOG_ERROR log_error;
 
+void set_log_verbosity(int);
 void set_log_verbose(void *func_ptr);
 void set_log_info(void *func_ptr);
 void set_log_error(void *func_ptr);

--- a/switchres.cpp
+++ b/switchres.cpp
@@ -31,6 +31,7 @@ const string WHITESPACE = " \n\r\t\f\v";
 //  logging
 //============================================================
 
+void switchres_manager::set_log_level(int log_level) { set_log_verbosity(log_level); }
 void switchres_manager::set_log_verbose_fn(void *func_ptr) { set_log_verbose((void *)func_ptr); }
 void switchres_manager::set_log_info_fn(void *func_ptr) { set_log_info((void *)func_ptr); }
 void switchres_manager::set_log_error_fn(void *func_ptr) { set_log_error((void *)func_ptr); }
@@ -323,6 +324,15 @@ bool switchres_manager::parse_config(const char *file_name)
 				case s2i("custom_timing"):
 					set_custom_timing(value.c_str());
 					break;
+
+				// Various
+				case s2i("verbosity"):
+				{
+					int verbosity_level = 1;
+					sscanf(value.c_str(), "%d", &verbosity_level);
+					set_log_level(verbosity_level);
+					break;
+				}
 
 				default:
 					log_error("Invalid option %s\n", key.c_str());

--- a/switchres.h
+++ b/switchres.h
@@ -50,6 +50,7 @@ public:
 	display_manager *display(int i) const { return i < (int)displays.size()? displays[i] : nullptr; }
 
 	// setters (log manager)
+	void set_log_level(int log_level);
 	void set_log_verbose_fn(void *func_ptr);
 	void set_log_info_fn(void *func_ptr);
 	void set_log_error_fn(void *func_ptr);

--- a/switchres.ini
+++ b/switchres.ini
@@ -52,3 +52,13 @@ screen_compositing        0
 screen_reordering         0
 allow_hardware_refresh    0
 custom_timing             auto
+
+#
+# Others
+#
+# Verbosity: from 0 to 3
+# 0: no message from SR
+# 1: only errors
+# 2: general information
+# 3: debug messages
+verbosity                 1

--- a/switchres_wrapper.cpp
+++ b/switchres_wrapper.cpp
@@ -29,8 +29,8 @@ MODULE_API void sr_init() {
 	setlocale(LC_NUMERIC, "C");
 	swr = new switchres_manager;
 	//swr->set_log_verbose_fn((void *)printf);
-	swr->set_log_info_fn((void *)printf);
-	swr->set_log_error_fn((void *)printf);
+	//swr->set_log_info_fn((void *)printf);
+	//swr->set_log_error_fn((void *)printf);
 	swr->parse_config("switchres.ini");
 }
 
@@ -170,6 +170,26 @@ MODULE_API void sr_set_rotation (unsigned char r) {
 }
 
 
+MODULE_API void sr_set_log_level (int l) {
+	swr->set_log_level(l);
+}
+
+
+MODULE_API void sr_set_log_callback_info (void * f) {
+	swr->set_log_info_fn((void *)f);
+}
+
+
+MODULE_API void sr_set_log_callback_debug (void * f) {
+	swr->set_log_verbose_fn((void *)f);
+}
+
+
+MODULE_API void sr_set_log_callback_error (void * f) {
+	swr->set_log_error_fn((void *)f);
+}
+
+
 MODULE_API srAPI srlib = {
 	sr_init,
 	sr_load_ini,
@@ -177,7 +197,11 @@ MODULE_API srAPI srlib = {
 	sr_init_disp,
 	sr_add_mode,
 	sr_switch_to_mode,
-	sr_set_rotation
+	sr_set_rotation,
+	sr_set_log_level,
+	sr_set_log_callback_error,
+	sr_set_log_callback_info,
+	sr_set_log_callback_debug,
 };
 
 #ifdef __cplusplus

--- a/switchres_wrapper.h
+++ b/switchres_wrapper.h
@@ -73,6 +73,8 @@ typedef struct MODULE_API {
 	unsigned char interlace;
 } sr_mode;
 
+
+// Declaration of the wrapper functions
 MODULE_API void sr_init();
 MODULE_API void sr_load_ini(char* config);
 MODULE_API void sr_deinit();
@@ -81,6 +83,12 @@ MODULE_API unsigned char sr_add_mode(int, int, double, unsigned char, sr_mode*);
 MODULE_API unsigned char sr_switch_to_mode(int, int, double, unsigned char, sr_mode*);
 MODULE_API void sr_set_monitor(const char*);
 MODULE_API void sr_set_rotation(unsigned char);
+
+// Logging related functions
+MODULE_API void sr_set_log_level (int);
+MODULE_API void sr_set_log_callback_error(void *);
+MODULE_API void sr_set_log_callback_info(void *);
+MODULE_API void sr_set_log_callback_debug(void *);
 
 
 // Inspired by https://stackoverflow.com/a/1067684
@@ -92,6 +100,10 @@ typedef struct MODULE_API {
     unsigned char (*sr_add_mode)(int, int, double, unsigned char, sr_mode*);
     unsigned char (*sr_switch_to_mode)(int, int, double, unsigned char, sr_mode*);
     void (*sr_set_rotation)(unsigned char);
+    void (*sr_set_log_level) (int);
+    void (*sr_set_log_callback_error)(void *);
+    void (*sr_set_log_callback_info)(void *);
+    void (*sr_set_log_callback_debug)(void *);
 } srAPI;
 
 


### PR DESCRIPTION
See the switchres.ini for details
The verbosity level **MUST** be set before branching the log function pointers.
Tested fine with Retroarch