### PR TITLE
API: sr_init_disp takes an argument (screen index/name)

### DIFF
--- a/display_linux.cpp
+++ b/display_linux.cpp
@@ -54,7 +54,8 @@ bool linux_display::init()
 
 	set_factory(new custom_video);
 	set_custom_video(factory()->make(m_ds.screen, NULL, method, &m_ds.vs));
-	if (video()) video()->init();
+	if (!video() or !video()->init())
+		return false;
 
 	// Build our display's mode list
 	video_modes.clear();

--- a/switchres_wrapper.cpp
+++ b/switchres_wrapper.cpp
@@ -31,16 +31,21 @@ MODULE_API void sr_init() {
 	swr->parse_config("switchres.ini");
 }
 
+
 MODULE_API void sr_load_ini(char* config) {
 	swr->parse_config(config);
-
 }
 
-MODULE_API void sr_init_disp() {
+
+MODULE_API unsigned char sr_init_disp(const char* scr) {
+	if (scr)
+		swr->set_screen(scr);
 	swr->add_display();
-	for (auto &display : swr->displays)
-		display->init();
+	if (!swr->display()->init())
+		return 0;
+	return 1;
 }
+
 
 MODULE_API void sr_deinit() {
 	delete swr;
@@ -50,6 +55,7 @@ MODULE_API void sr_deinit() {
 MODULE_API void sr_set_monitor(const char *preset) {
 	swr->set_monitor(preset);
 }
+
 
 void disp_best_mode_to_sr_mode(display_manager* disp, sr_mode* srm)
 {

--- a/switchres_wrapper.h
+++ b/switchres_wrapper.h
@@ -78,7 +78,7 @@ typedef struct MODULE_API {
 MODULE_API void sr_init();
 MODULE_API void sr_load_ini(char* config);
 MODULE_API void sr_deinit();
-MODULE_API void sr_init_disp();
+MODULE_API unsigned char sr_init_disp(const char* src);
 MODULE_API unsigned char sr_add_mode(int, int, double, unsigned char, sr_mode*);
 MODULE_API unsigned char sr_switch_to_mode(int, int, double, unsigned char, sr_mode*);
 MODULE_API void sr_set_monitor(const char*);
@@ -96,7 +96,7 @@ typedef struct MODULE_API {
     void (*init)(void);
     void (*sr_sr_load_ini)(char*);
     void (*deinit)(void);
-    void (*sr_init_disp)(void);
+    unsigned char (*sr_init_disp)(const char*);
     unsigned char (*sr_add_mode)(int, int, double, unsigned char, sr_mode*);
     unsigned char (*sr_switch_to_mode)(int, int, double, unsigned char, sr_mode*);
     void (*sr_set_rotation)(unsigned char);


### PR DESCRIPTION
This is a breaking change in the API. Emulators can specify a screen index/name passwed to `switchres_manager->set_screen()`

Also fixed the linux display init() never returning false.