### PR TITLE
DRMKMS: build only if libdrm has the required version

### DIFF
--- a/custom_video.cpp
+++ b/custom_video.cpp
@@ -24,7 +24,9 @@
 #include "custom_video_pstrip.h"
 #elif defined(__linux__)
 #include "custom_video_xrandr.h"
+#ifdef SR_WITH_KMSDRM
 #include "custom_video_drmkms.h"
+#endif
 #endif
 
 
@@ -93,6 +95,7 @@ custom_video *custom_video::make(char *device_name, char *device_id, int method,
 		}
 	}
 
+#ifdef SR_WITH_KMSDRM
 	if (method == CUSTOM_VIDEO_TIMING_DRMKMS || method == 0)
 	{
 		m_custom_video = new drmkms_timing(device_name, vs);
@@ -102,6 +105,7 @@ custom_video *custom_video::make(char *device_name, char *device_id, int method,
 			return m_custom_video;
 		}
 	}
+#endif /* SR_WITH_KMSDRM */
 #endif
 
 	return this;

--- a/custom_video.cpp
+++ b/custom_video.cpp
@@ -23,7 +23,9 @@
 #include "custom_video_adl.h"
 #include "custom_video_pstrip.h"
 #elif defined(__linux__)
+#ifdef SR_WITH_XRANDR
 #include "custom_video_xrandr.h"
+#endif
 #ifdef SR_WITH_KMSDRM
 #include "custom_video_drmkms.h"
 #endif
@@ -81,6 +83,7 @@ custom_video *custom_video::make(char *device_name, char *device_id, int method,
 	if (device_id != NULL)
 		log_info("Device value is %s.\n", device_id);
 
+#ifdef SR_WITH_XRANDR
 	if (method == CUSTOM_VIDEO_TIMING_XRANDR || method == 0)
 	{
 		try
@@ -94,6 +97,7 @@ custom_video *custom_video::make(char *device_name, char *device_id, int method,
 			return m_custom_video;
 		}
 	}
+#endif /* SR_WITH_XRANDR */
 
 #ifdef SR_WITH_KMSDRM
 	if (method == CUSTOM_VIDEO_TIMING_DRMKMS || method == 0)

--- a/display_linux.cpp
+++ b/display_linux.cpp
@@ -49,8 +49,10 @@ bool linux_display::init()
 
 	if (!strcmp(m_ds.api, "xrandr"))
 		method = CUSTOM_VIDEO_TIMING_XRANDR;
+#ifdef SR_WITH_KMSDRM
 	else if (!strcmp(m_ds.api, "drmkms"))
 		method = CUSTOM_VIDEO_TIMING_DRMKMS;
+#endif
 
 	set_factory(new custom_video);
 	set_custom_video(factory()->make(m_ds.screen, NULL, method, &m_ds.vs));

--- a/display_linux.cpp
+++ b/display_linux.cpp
@@ -47,10 +47,12 @@ bool linux_display::init()
 	// Initialize custom video
 	int method = CUSTOM_VIDEO_TIMING_AUTO;
 
+#ifdef SR_WITH_XRANDR
 	if (!strcmp(m_ds.api, "xrandr"))
 		method = CUSTOM_VIDEO_TIMING_XRANDR;
+#endif
 #ifdef SR_WITH_KMSDRM
-	else if (!strcmp(m_ds.api, "drmkms"))
+	if (!strcmp(m_ds.api, "drmkms"))
 		method = CUSTOM_VIDEO_TIMING_DRMKMS;
 #endif
 

--- a/makefile
+++ b/makefile
@@ -27,12 +27,21 @@ PKGDIR = $(LIBDIR)/pkgconfig
 
 # Linux
 ifeq  ($(PLATFORM),Linux)
-EXTRA_LIBS = libdrm
+SRC += display_linux.cpp custom_video_xrandr.cpp
+HAS_VALID_DRMKMS := $(shell $(PKG_CONFIG) --libs "libdrm >= 2.4.98"; echo $$?)
+ifeq ($(HAS_VALID_DRMKMS),1)
+    $(info Switchres needs libdrm >= 2.4.98. KMS support is disabled)
+else
+    CPPFLAGS += -DSR_WITH_KMSDRM
+    EXTRA_LIBS = libdrm
+    SRC += custom_video_drmkms.cpp
+endif
+ifneq (,$(EXTRA_LIBS))
 CPPFLAGS += $(shell $(PKG_CONFIG) --cflags $(EXTRA_LIBS))
-SRC += display_linux.cpp custom_video_xrandr.cpp custom_video_drmkms.cpp
+endif
 CPPFLAGS += -fPIC
 LIBS = -ldl
-REMOVE = rm -f 
+REMOVE = rm -f
 STATIC_LIB_EXT = a
 DYNAMIC_LIB_EXT = so
 
@@ -40,7 +49,7 @@ DYNAMIC_LIB_EXT = so
 else ifneq (,$(findstring NT,$(PLATFORM)))
 SRC += display_windows.cpp custom_video_ati_family.cpp custom_video_ati.cpp custom_video_adl.cpp custom_video_pstrip.cpp resync_windows.cpp
 CPPFLAGS += -static -static-libgcc -static-libstdc++
-LIBS = 
+LIBS =
 #REMOVE = del /f
 REMOVE = rm -f
 STATIC_LIB_EXT = lib


### PR DESCRIPTION
Some systems' libdrm is to old and don't have `drmIsMaster`, thus failing compilation. As KMS support is still pretty alpha, here are the changes done:

- new define : SR_WITH_KMSDRM that will enable or not KMS support in the code
- the makefile will use pkg-config to check if libdrm version is >= 2.4.98, and then define SR_WITH_KMSDRM accordingly