### PR TITLE
Allow reloading of settings from ini and allow absolute path to ini file

### DIFF
--- a/switchres.cpp
+++ b/switchres.cpp
@@ -22,9 +22,9 @@ using namespace std;
 const string WHITESPACE = " \n\r\t\f\v";
 
 #if defined(_WIN32)
-	#define SR_CONFIG_PATHS ".\\;.\\ini\\;"
+	#define SR_CONFIG_PATHS ";.\\;.\\ini\\;"
 #elif defined(__linux__)
-	#define SR_CONFIG_PATHS "./;./ini/;/etc/;"
+	#define SR_CONFIG_PATHS ";./;./ini/;/etc/;"
 #endif
 
 //============================================================
@@ -244,14 +244,16 @@ bool switchres_manager::parse_config(const char *file_name)
 					break;
 				case s2i("user_mode"):
 				{
+					modeline user_mode = {};
 					if (strcmp(value.c_str(), "auto"))
 					{
-						modeline user_mode = {};
 						if (sscanf(value.c_str(), "%dx%d@%d", &user_mode.width, &user_mode.height, &user_mode.refresh) < 1)
+						{
 							log_error("Error: use format resolution <w>x<h>@<r>\n");
-						else
-							set_user_mode(&user_mode);
+							break;
+						}
 					}
+					set_user_mode(&user_mode);
 					break;
 				}
 

--- a/switchres_wrapper.cpp
+++ b/switchres_wrapper.cpp
@@ -34,6 +34,8 @@ MODULE_API void sr_init() {
 
 MODULE_API void sr_load_ini(char* config) {
 	swr->parse_config(config);
+	swr->display()->m_ds = swr->ds;
+	swr->display()->parse_options();
 }
 
 


### PR DESCRIPTION
I'm currently working on a feature for RetroArch that allows for core-specific switchres.ini overrides. This new functionality will work by reloading the base `switchres.ini` file (to undo any overrides from a previous core) and then loading the values from the core-specific `switchres.ini` file on top of it, replacing the previous values.

Currently it is not possible/stable to deinit/reinit SwitchRes inside RetroArch once it is running, but it is simple to just change the settings as they take effect on the following resolution changes. On my tests I was able to have a core-specific `user_mode` that got reverted as soon as the content was closed.

This pull request is relative to changes to the SwitchRes library that would be necessary to make the rest of the system work on RetroArch. They are as follows:

- Allow loading of a `switchres.ini` file by passing in an absolute path, done by adding an empty path to the `SR_CONFIG_PATHS` constant;
- Making the `sr_load_ini` method on the wrapper send the new settings to current displays for re-parsing;
- Making a small change to how the `user_mode` setting is handled when `auto` is passed so it resets any previously passed value.

If this pull request is accepted then I can pull the changes to the SwitchRes library into a fork of the https://github.com/alphanu1/MME_SR2 repository and make a pull request over there with the additional functionality to complete the new feature.