### PR TITLE
fix: properly handle exceptions

### DIFF
--- a/custom_video_xrandr.cpp
+++ b/custom_video_xrandr.cpp
@@ -132,21 +132,21 @@ xrandr_timing::xrandr_timing(char *device_name, custom_video_settings *vs)
 		if (p_XOpenDisplay == NULL)
 		{
 			log_error("XRANDR: <%d> (xrandr_timing) [ERROR] missing func %s in %s\n", m_id, "XOpenDisplay", "X11_LIBRARY");
-			throw new std::exception();
+			throw std::exception();
 		}
 		else
 		{
 			if (!XOpenDisplay(NULL))
 			{
 				log_verbose("XRANDR: <%d> (xrandr_timing) X server not found\n", m_id);
-				throw new std::exception();
+				throw std::exception();
 			}
 		}
 	}
 	else
 	{
 		log_error("XRANDR: <%d> (xrandr_timing) [ERROR] missing %s library\n", m_id, "X11_LIBRARY");
-		throw new std::exception();
+		throw std::exception();
 	}
 
 	s_total_managed_screen++;

--- a/display_sdl2.cpp
+++ b/display_sdl2.cpp
@@ -92,13 +92,13 @@ sdl2_display::sdl2_display(display_settings *ds)
 	else
 	{
 		log_verbose("Switchres/SDL2: (%s): SDL2 video wasn't initialized\n", __FUNCTION__);
-		throw new std::exception();
+		throw std::exception();
 	}
 	// For now, only allow the SDL2 display manager for the KMSDRM backend
 	if ( strcmp("KMSDRM", SDL_GetCurrentVideoDriver()) != 0 )
 	{
 		log_info("Switchres/SDL2: (%s): SDL2 is only available for KMSDRM for now.\n", __FUNCTION__);
-		throw new std::exception();
+		throw std::exception();
 	}
 
 	// Get display settings


### PR DESCRIPTION
throw new std::exception() will throw a pointer; since C++ is not garbage collected, dynamically allocating exceptions in this way is costly and can have unexpected behavior