### PR TITLE
Add arcade_15_31 preset to switchres.ini

### DIFF
--- a/switchres.ini
+++ b/switchres.ini
@@ -4,18 +4,18 @@
 
 # Monitor preset. Sets typical monitor operational ranges:
 #
-# generic_15, ntsc, pal                    Generic CRT standards
-# arcade_15, arcade_15ex                   Arcade fixed frequency
-# arcade_25, arcade_31                     Arcade fixed frequency
-# arcade_15_25, arcade_15_25_31            Arcade multisync
-# vesa_480, vesa_600, vesa_768, vesa_1024  VESA GTF
-# pc_31_120, pc_70_120                     PC monitor 120 Hz
-# h9110, polo, pstar                       Hantarex
-# k7000, k7131, d9200, d9800, d9400        Wells Gardner
-# m2929                                    Makvision
-# m3129                                    Wei-Ya
-# ms2930, ms929                            Nanao
-# r666b                                    Rodotron
+# generic_15, ntsc, pal                    	Generic CRT standards
+# arcade_15, arcade_15ex                   	Arcade fixed frequency
+# arcade_25, arcade_31                     	Arcade fixed frequency
+# arcade_15_25, arcade_15_31, arcade_15_25_31   Arcade multisync
+# vesa_480, vesa_600, vesa_768, vesa_1024  	VESA GTF
+# pc_31_120, pc_70_120                     	PC monitor 120 Hz
+# h9110, polo, pstar                       	Hantarex
+# k7000, k7131, d9200, d9800, d9400        	Wells Gardner
+# m2929                                    	Makvision
+# m3129                                    	Wei-Ya
+# ms2930, ms929                            	Nanao
+# r666b                                    	Rodotron
 #
 # Special presets:
 # custom   Defines a custom preset. Use in combination with crt_range0-9 options below.


### PR DESCRIPTION
### Add `arcade_15_31` preset to `switchres.ini`

This update adds the missing `arcade_15_31` monitor preset to the `switchres.ini` configuration file.

The preset is already defined in the source code ([monitor.cpp](https://github.com/antonioginer/switchres/blob/725e4d484a33632618dd44cdc2a61948dd833282/monitor.cpp#L175)) but was not listed in the example configuration, which could lead to confusion and prevent users from utilizing it.

This change brings the configuration file in line with the available monitor presets in the codebase.
